### PR TITLE
Add schema tree parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# gitlabschema
+# GitLab Schema
+
+This repository contains a GraphQL schema introspection JSON (`schema.json`).
+
+## parse_schema.py
+
+`parse_schema.py` reads the introspection file and prints a simplified tree
+representation in the form `type -> [{field, type}]` recursively. Repeated
+references are truncated to avoid cycles.
+
+Usage:
+
+```bash
+python3 parse_schema.py [schema.json]
+```
+
+Without an argument it defaults to `schema.json` in the repository root.

--- a/parse_schema.py
+++ b/parse_schema.py
@@ -1,0 +1,53 @@
+import json
+import sys
+from typing import Dict, List, Any, Set
+
+# simple script to output a nesting of types -> [{field, type}] recursively
+# usage: python parse_schema.py [schema.json]
+
+def load_schema(path: str) -> Dict[str, Any]:
+    with open(path, 'r') as f:
+        data = json.load(f)
+    schema = data.get("data", {}).get("__schema", {})
+    types = schema.get("types", [])
+    return {t["name"]: t for t in types if "name" in t}
+
+
+def get_base_type(t: Dict[str, Any]) -> str:
+    """Recursively unwrap LIST and NON_NULL wrappers to get base type name."""
+    kind = t.get("kind")
+    name = t.get("name")
+    of_type = t.get("ofType")
+    if kind in ("NON_NULL", "LIST") and of_type:
+        return get_base_type(of_type)
+    return name
+
+
+def build_fields(type_name: str, type_map: Dict[str, Any], seen: Set[str]) -> List[Dict[str, Any]]:
+    if type_name in seen:
+        return []  # avoid cycles
+    seen.add(type_name)
+    t = type_map.get(type_name)
+    fields = []
+    if t and t.get("fields"):
+        for f in t["fields"]:
+            base = get_base_type(f["type"])
+            entry = {"field": f["name"], "type": base}
+            if base not in seen and type_map.get(base, {}).get("fields"):
+                entry["fields"] = build_fields(base, type_map, seen.copy())
+            fields.append(entry)
+    return fields
+
+
+def main():
+    path = sys.argv[1] if len(sys.argv) > 1 else "schema.json"
+    type_map = load_schema(path)
+    result = {}
+    for name, t in type_map.items():
+        if t.get("fields"):
+            result[name] = build_fields(name, type_map, set())
+    json.dump(result, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a parser script that outputs a nested field tree with cycle prevention
- document the script in the README

## Testing
- `python3 -m py_compile parse_schema.py`


------
https://chatgpt.com/codex/tasks/task_e_68854b2df99c832485ab92999b86c1af