### PR TITLE
Improve parsing speed

### DIFF
--- a/parse_schema.py
+++ b/parse_schema.py
@@ -1,13 +1,24 @@
-import json
 import sys
 from typing import Dict, List, Any, Set
+
+try:
+    import orjson as _orjson  # type: ignore
+    _json = _orjson
+    _HAS_ORJSON = True
+except ImportError:  # fallback to builtin json
+    import json as _json
+    _HAS_ORJSON = False
 
 # simple script to output a nesting of types -> [{field, type}] recursively
 # usage: python parse_schema.py [schema.json]
 
 def load_schema(path: str) -> Dict[str, Any]:
-    with open(path, 'r') as f:
-        data = json.load(f)
+    mode = 'rb' if _HAS_ORJSON else 'r'
+    with open(path, mode) as f:
+        if _HAS_ORJSON:
+            data = _json.loads(f.read())
+        else:
+            data = _json.load(f)
     schema = data.get("data", {}).get("__schema", {})
     types = schema.get("types", [])
     return {t["name"]: t for t in types if "name" in t}
@@ -34,8 +45,9 @@ def build_fields(type_name: str, type_map: Dict[str, Any], seen: Set[str]) -> Li
             base = get_base_type(f["type"])
             entry = {"field": f["name"], "type": base}
             if base not in seen and type_map.get(base, {}).get("fields"):
-                entry["fields"] = build_fields(base, type_map, seen.copy())
+                entry["fields"] = build_fields(base, type_map, seen)
             fields.append(entry)
+    seen.remove(type_name)
     return fields
 
 
@@ -46,7 +58,10 @@ def main():
     for name, t in type_map.items():
         if t.get("fields"):
             result[name] = build_fields(name, type_map, set())
-    json.dump(result, sys.stdout, indent=2)
+    if _HAS_ORJSON:
+        sys.stdout.buffer.write(_json.dumps(result, option=_orjson.OPT_INDENT_2))
+    else:
+        _json.dump(result, sys.stdout, indent=2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- optimize schema parser by keeping track of seen types without copying sets
- use `orjson` when available for faster JSON processing

## Testing
- `python3 parse_schema.py test_schema.json`

------
https://chatgpt.com/codex/tasks/task_e_68854c310c108324825692aecb58a5d2