### PR TITLE
Rewrite schema parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ This repository contains a GraphQL schema introspection JSON (`schema.json`).
 
 ## parse_schema.py
 
-`parse_schema.py` reads the introspection file and prints a simplified tree
-representation in the form `type -> [{field, type}]` recursively. Repeated
-references are truncated to avoid cycles.
+`parse_schema.py` reads the introspection file and prints a simplified
+mapping of each type to its immediate fields. Each field is represented by
+its name and the base type name. The output is a JSON object of the form
+`{type: [{field, type}]}` which is significantly smaller and faster to
+generate than the previous recursive version.
 
 Usage:
 

--- a/parse_schema.py
+++ b/parse_schema.py
@@ -1,63 +1,54 @@
 import sys
-from typing import Dict, List, Any, Set
+from typing import Dict, List, Any
 
 try:
     import orjson as _orjson  # type: ignore
     _json = _orjson
     _HAS_ORJSON = True
-except ImportError:  # fallback to builtin json
+except ImportError:  # pragma: no cover - optional dependency
     import json as _json
     _HAS_ORJSON = False
 
-# simple script to output a nesting of types -> [{field, type}] recursively
-# usage: python parse_schema.py [schema.json]
 
 def load_schema(path: str) -> Dict[str, Any]:
-    mode = 'rb' if _HAS_ORJSON else 'r'
+    """Load introspection schema and return a mapping of type name to type data."""
+    mode = "rb" if _HAS_ORJSON else "r"
     with open(path, mode) as f:
-        if _HAS_ORJSON:
-            data = _json.loads(f.read())
-        else:
-            data = _json.load(f)
+        data = _json.loads(f.read()) if _HAS_ORJSON else _json.load(f)
     schema = data.get("data", {}).get("__schema", {})
     types = schema.get("types", [])
     return {t["name"]: t for t in types if "name" in t}
 
 
 def get_base_type(t: Dict[str, Any]) -> str:
-    """Recursively unwrap LIST and NON_NULL wrappers to get base type name."""
+    """Recursively unwrap LIST/NON_NULL wrappers to get the underlying type name."""
     kind = t.get("kind")
     name = t.get("name")
     of_type = t.get("ofType")
     if kind in ("NON_NULL", "LIST") and of_type:
         return get_base_type(of_type)
-    return name
+    return name or ""
 
 
-def build_fields(type_name: str, type_map: Dict[str, Any], seen: Set[str]) -> List[Dict[str, Any]]:
-    if type_name in seen:
-        return []  # avoid cycles
-    seen.add(type_name)
-    t = type_map.get(type_name)
-    fields = []
-    if t and t.get("fields"):
-        for f in t["fields"]:
-            base = get_base_type(f["type"])
-            entry = {"field": f["name"], "type": base}
-            if base not in seen and type_map.get(base, {}).get("fields"):
-                entry["fields"] = build_fields(base, type_map, seen)
-            fields.append(entry)
-    seen.remove(type_name)
-    return fields
+def extract_fields(type_map: Dict[str, Any]) -> Dict[str, List[Dict[str, str]]]:
+    """Return simplified mapping of type -> [{field, type}] (non-recursive)."""
+    result: Dict[str, List[Dict[str, str]]] = {}
+    for name, t in type_map.items():
+        fields = t.get("fields")
+        if not fields:
+            continue
+        entries = []
+        for f in fields:
+            base = get_base_type(f.get("type", {}))
+            entries.append({"field": f.get("name", ""), "type": base})
+        result[name] = entries
+    return result
 
 
-def main():
+def main() -> None:
     path = sys.argv[1] if len(sys.argv) > 1 else "schema.json"
     type_map = load_schema(path)
-    result = {}
-    for name, t in type_map.items():
-        if t.get("fields"):
-            result[name] = build_fields(name, type_map, set())
+    result = extract_fields(type_map)
     if _HAS_ORJSON:
         sys.stdout.buffer.write(_json.dumps(result, option=_orjson.OPT_INDENT_2))
     else:


### PR DESCRIPTION
## Summary
- rewrite `parse_schema.py` to simply map each type to its immediate fields
- update README to describe the simplified parser

## Testing
- `python3 parse_schema.py schema.json >/tmp/out.txt`
- `wc -c /tmp/out.txt`

------
https://chatgpt.com/codex/tasks/task_e_68854e184a08832495e31144bfe27f2a