### PR TITLE
Filter out boilerplate GraphQL types

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ This repository contains a GraphQL schema introspection JSON (`schema.json`).
 ## parse_schema.py
 
 `parse_schema.py` reads the introspection file and prints a simplified
-mapping of each type to its immediate fields. Each field is represented by
-its name and the base type name. The output is a JSON object of the form
-`{type: [{field, type}]}` which is significantly smaller and faster to
-generate than the previous recursive version.
+mapping of each domain type to its immediate fields. Introspection types,
+connection/edge types and mutation payloads are omitted. Each field is
+represented by its name and the base type name. The output is a JSON object
+of the form `{type: [{field, type}]}` which is significantly smaller and
+faster to generate than the previous recursive version.
 
 Usage:
 


### PR DESCRIPTION
## Summary
- only include domain object/interface types when extracting fields
- mention new filtering behavior in the README

## Testing
- `python3 parse_schema.py schema.json > /tmp/out.json`

------
https://chatgpt.com/codex/tasks/task_e_6885558b4c2c8324b31acc8c9eda6e6e