### PR TITLE
Add stats mode for schema parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ form `{type: [{field, type, fields?}]}`.
 
 Recursion depth can be expensive on large schemas. The parser therefore
 defaults to following fields only three levels deep. Use the `--depth` option to
-increase or decrease this limit.
+increase or decrease this limit. Passing `--stats` will print a summary instead
+of the full nested mapping.
 
 Usage:
 
 ```bash
-python3 parse_schema.py [--depth N] [schema.json]
+python3 parse_schema.py [--depth N] [--stats] [schema.json]
 ```
 
 Without an argument it defaults to `schema.json` in the repository root and a


### PR DESCRIPTION
## Summary
- add `--stats` flag to `parse_schema.py` to print counts of unique paths and types
- mention stats flag in README

## Testing
- `python3 -m py_compile parse_schema.py`
- `python3 parse_schema.py --depth 1 --stats schema.json | head`
- `python3 parse_schema.py --depth 0 schema.json > /tmp/out && head -n 5 /tmp/out`

------
https://chatgpt.com/codex/tasks/task_e_68855d20fe088324a1002a71c0565157